### PR TITLE
Implement --fill_gap_size and --do_not_remove_puncs flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,31 @@ language of the target dataset. Both datasets should have the same number of sen
 --source_augmentation /path/to/source_augmentation.txt
 --target_augmentation /path/to/target_augmentation.txt
 ````
+
+### Hyperparameters:
+There are two hyperparameters that you can modify to tune the projection algorithm to your dataset.
+
+Punctuation: By default we remove punctuation from the alignments to prevent projecting a word into a punctuation mark. 
+We do this because in the NER and Absa datasets a punctuation is never annotated, but this may not be the case for other datasets.
+If you want to allow labels in the source sentence to be projected into punctuation marks, set the `--do_not_remove_puncs` flag. 
+i.e If `coffee` is projected into `café .`, we will not remove the `.` from the alignment.
+
+Gaps in the alignments: If a label in the source sentence is split in two or more parts in the target sentence, we will
+fill the gap considering the unlabelled words between the parts as labelled word with the same class if the gap
+is equal or lower than "--fill_gap_size" words (by default 1). i.e if we project a label and we get the following labels:  
+`O B-LOC I-LOC O I-LOC O O` we will fill the gap and get `O B-LOC I-LOC I-LOC I-LOC O O`. 
+Use True 1 if you are projection named entities or labels with a small number of words. 
+Use a larger value for argumentation datasets and datasets in which the labels are long sentences.
+
+````commandline
+--fill_gap_size 1 \
+--do_not_remove_puncs
+````
+
+If you want to test different hyperparameters without computing the alignments again, you can use the 
+`--use_existing_alignments` flag. You must use the same `--output_dir` and `--output_name` as the previous run and the same 
+train, dev and test files.
+
 ## Generate word alignments
 If you only want to generate word alignments, you can use the "generate_alignments.py" script.
 This script has the same parameters as the "annotation_projection.py" script, but the source and target datasets

--- a/README.md
+++ b/README.md
@@ -142,16 +142,17 @@ language of the target dataset. Both datasets should have the same number of sen
 ### Hyperparameters:
 There are two hyperparameters that you can modify to tune the projection algorithm to your dataset.
 
-Punctuation: By default we remove punctuation from the alignments to prevent projecting a word into a punctuation mark. 
-We do this because in the NER and Absa datasets a punctuation is never annotated, but this may not be the case for other datasets.
+***Punctuation***: By default we remove punctuation from the alignments to prevent projecting a word into a punctuation mark. 
+We do this because in the NER and ABSA datasets a punctuation is never annotated, but this may not be the case for other datasets.
 If you want to allow labels in the source sentence to be projected into punctuation marks, set the `--do_not_remove_puncs` flag. 
-i.e If `coffee` is projected into `café .`, we will not remove the `.` from the alignment.
+For example, If `coffee` is projected into `café .` we will remove the `.` from the alignment. 
+But we will not remove the `.` if the flag `--do_not_remove_puncs` is set.
 
-Gaps in the alignments: If a label in the source sentence is split in two or more parts in the target sentence, we will
-fill the gap considering the unlabelled words between the parts as labelled word with the same class if the gap
-is equal or lower than "--fill_gap_size" words (by default 1). i.e if we project a label and we get the following labels:  
+***Gaps in the alignments***: If a label in the source sentence is split in two or more parts in the target sentence, we will
+fill the gap considering the unlabelled words between the parts as labelled words with the same class if the gap
+is equal or lower than "--fill_gap_size" words (by default 1). For example, if we project a label and we get the following labels:  
 `O B-LOC I-LOC O I-LOC O O` we will fill the gap and get `O B-LOC I-LOC I-LOC I-LOC O O`. 
-Use True 1 if you are projection named entities or labels with a small number of words. 
+Use True 1 if you are projecting named entities or labels with a small number of words. 
 Use a larger value for argumentation datasets and datasets in which the labels are long sentences.
 
 ````commandline

--- a/annotation_projection.py
+++ b/annotation_projection.py
@@ -250,7 +250,7 @@ def run_projection(
     do_awesome: bool = False,
     remove_awesome_model: bool = True,
     awesome_model_path: str = None,
-    remove_puncs: bool = False,
+    remove_puncs: bool = True,
     fill_gap_size: int = 1,
     use_existing_alignments: bool = False,
 ):
@@ -609,5 +609,7 @@ if __name__ == "__main__":
         do_awesome=args.do_awesome,
         remove_awesome_model=args.remove_awesome_model,
         awesome_model_path=args.awesome_model_path,
+        remove_puncs=args.do_not_remove_puncs,
+        fill_gap_size=args.fill_gap_size,
         use_existing_alignments=args.use_existing_alignments,
     )

--- a/annotation_projection.py
+++ b/annotation_projection.py
@@ -252,6 +252,7 @@ def run_projection(
     awesome_model_path: str = None,
     remove_puncs: bool = False,
     fill_gap_size: int = 1,
+    use_existing_alignments: bool = False,
 ):
     """
     Perform annotation projection for the given datasets.
@@ -278,6 +279,9 @@ def run_projection(
     less or equal than fill_gap_size. Else we will choose the largest label and remove the other part.
     Use True 1 if you are projection named entities or labels with a small number of words.
     Use a larger value for argumentation datasets and datasets in which the labels are long sentences.
+    :param bool use_existing_alignments: Whether to use existing word alignments instead of generating new ones. You
+    must use the same --output_dir and --output_name as the one used to generate the word alignments. You must
+    also use the same train, dev and test files.
     """
 
     if not os.path.exists(output_dir):
@@ -357,24 +361,29 @@ def run_projection(
             f"Target ({target_augmentation}): {lines_target}"
         )
 
-    generate_alignments(
-        source_train=source_train_txt,
-        target_train=target_train,
-        source_dev=source_dev_txt,
-        target_dev=target_dev,
-        source_test=source_test_txt,
-        target_test=target_test,
-        source_augmentation=source_augmentation,
-        target_augmentation=target_augmentation,
-        output_dir=output_dir,
-        output_name=output_name,
-        do_fastalign=do_fastalign,
-        do_mgiza=do_mgiza,
-        do_simalign=do_simalign,
-        do_awesome=do_awesome,
-        remove_awesome_model=remove_awesome_model,
-        awesome_model_path=awesome_model_path,
-    )
+    if not use_existing_alignments:
+        generate_alignments(
+            source_train=source_train_txt,
+            target_train=target_train,
+            source_dev=source_dev_txt,
+            target_dev=target_dev,
+            source_test=source_test_txt,
+            target_test=target_test,
+            source_augmentation=source_augmentation,
+            target_augmentation=target_augmentation,
+            output_dir=output_dir,
+            output_name=output_name,
+            do_fastalign=do_fastalign,
+            do_mgiza=do_mgiza,
+            do_simalign=do_simalign,
+            do_awesome=do_awesome,
+            remove_awesome_model=remove_awesome_model,
+            awesome_model_path=awesome_model_path,
+        )
+    else:
+        print(
+            f"--use_existing_alignments is set to True. We will attempt to use the existing word alignments."
+        )
 
     alignment_list = []
     if do_mgiza:
@@ -573,6 +582,14 @@ if __name__ == "__main__":
         "Use a larger value for argumentation datasets and datasets in which the labels are long sentences.",
     )
 
+    parser.add_argument(
+        "--use_existing_alignments",
+        action="store_true",
+        help="If set, the script will use the existing alignments in the output directory instead of generating "
+        "new ones. You should use the same --outpur_dir and --output_name as the previous run and the same "
+        "train, dev and test files.",
+    )
+
     args = parser.parse_args()
 
     run_projection(
@@ -592,4 +609,5 @@ if __name__ == "__main__":
         do_awesome=args.do_awesome,
         remove_awesome_model=args.remove_awesome_model,
         awesome_model_path=args.awesome_model_path,
+        use_existing_alignments=args.use_existing_alignments,
     )

--- a/annotation_projection.py
+++ b/annotation_projection.py
@@ -586,7 +586,7 @@ if __name__ == "__main__":
         "--use_existing_alignments",
         action="store_true",
         help="If set, the script will use the existing alignments in the output directory instead of generating "
-        "new ones. You should use the same --outpur_dir and --output_name as the previous run and the same "
+        "new ones. You should use the same --output_dir and --output_name as the previous run and the same "
         "train, dev and test files.",
     )
 

--- a/annotation_projection.py
+++ b/annotation_projection.py
@@ -577,7 +577,7 @@ if __name__ == "__main__":
         default=1,
         type=int,
         help="If the projected label is split in two or more parts, we fill the gap if the gap size is less or equal "
-        "than fill_gap_size. Else we will choose the largest label and remove the other part. "
+        "than fill_gap_size. Else shouldwe will choose the largest label and remove the other part. "
         "Use True 1 if you are projection named entities or labels with a small number of words. "
         "Use a larger value for argumentation datasets and datasets in which the labels are long sentences.",
     )
@@ -586,7 +586,7 @@ if __name__ == "__main__":
         "--use_existing_alignments",
         action="store_true",
         help="If set, the script will use the existing alignments in the output directory instead of generating "
-        "new ones. You should use the same --output_dir and --output_name as the previous run and the same "
+        "new ones. You must use the same --output_dir and --output_name as the previous run and the same "
         "train, dev and test files.",
     )
 

--- a/annotation_projection.py
+++ b/annotation_projection.py
@@ -250,6 +250,8 @@ def run_projection(
     do_awesome: bool = False,
     remove_awesome_model: bool = True,
     awesome_model_path: str = None,
+    remove_puncs: bool = False,
+    fill_gap_size: int = 1,
 ):
     """
     Perform annotation projection for the given datasets.
@@ -269,6 +271,13 @@ def run_projection(
     :param bool do_awesome: Whether to generate word alignments with awesome.
     :param bool remove_awesome_model: Whether to remove the trained awesome model after the alignment generation.
     :param str awesome_model_path: Path to a pretrained awesome model.
+    :param bool remove_puncs: If a source word is aligned to a punctuation mark, we remove the alignment.
+    Use True if you are projection named entities or labels with a small number of words.
+    Use false for argumentation datasets and datasets in which the labels are long sentences.
+    :param int fill_gap_size: If the projected label is split in two or more parts, we fill the gap if the gap size is
+    less or equal than fill_gap_size. Else we will choose the largest label and remove the other part.
+    Use True 1 if you are projection named entities or labels with a small number of words.
+    Use a larger value for argumentation datasets and datasets in which the labels are long sentences.
     """
 
     if not os.path.exists(output_dir):
@@ -429,6 +438,8 @@ def run_projection(
                 output_path=os.path.join(
                     output_dir, f"{output_name}.{alignment_method}.{dataset_split}.tsv"
                 ),
+                remove_puncs=remove_puncs,
+                fill_gap_size=fill_gap_size,
             )
 
             output_files.append(
@@ -542,6 +553,24 @@ if __name__ == "__main__":
         default=None,
         type=str,
         help="If provided, the path to a pretrained awesome model",
+    )
+
+    parser.add_argument(
+        "--do_not_remove_puncs",
+        action="store_false",
+        help="If a source word is aligned to a punctuation mark, we remove the alignment. "
+        "Do not set this flag if you are projection named entities or labels with a small number of words. "
+        "Use false for argumentation datasets and datasets in which the labels are long sentences.",
+    )
+
+    parser.add_argument(
+        "--fill_gap_size",
+        default=1,
+        type=int,
+        help="If the projected label is split in two or more parts, we fill the gap if the gap size is less or equal "
+        "than fill_gap_size. Else we will choose the largest label and remove the other part. "
+        "Use True 1 if you are projection named entities or labels with a small number of words. "
+        "Use a larger value for argumentation datasets and datasets in which the labels are long sentences.",
     )
 
     args = parser.parse_args()

--- a/projection/annotation_proyection.py
+++ b/projection/annotation_proyection.py
@@ -257,9 +257,11 @@ def dataset_projection(
         f"alignments_path: {alignments_path}.\n"
         f"batch_size: {batch_size}.\n"
         f"output_path:{output_path}.\n"
+        f"remove_puncs: {remove_puncs}.\n"
+        f"fill_gap_size: {fill_gap_size}.\n"
     )
-    if not os.path.exists(os.path.dirname(output_path)):
-        os.makedirs(os.path.dirname(output_path))
+
+    os.makedirs(os.path.abspath(os.path.dirname(output_path)), exist_ok=True)
 
     data_loader = ProjectionDataloader(
         source_tsv=source_dataset,

--- a/projection/annotation_proyection.py
+++ b/projection/annotation_proyection.py
@@ -5,6 +5,7 @@ from projection.dataset import ProjectionDataloader
 import math
 from tqdm.auto import tqdm
 import string
+from functools import partial
 
 puncs = set(string.punctuation)
 
@@ -23,6 +24,12 @@ def sentence_projection(
     source_tags_ids: List[List[int]],
     target_words: List[str],
     alignments: Dict,
+    remove_puncs: bool = True,  # If a source word is aligned to a punctuation mark, we remove the alignment.
+    # Use True if you are projection named entities or labels with a small number of words.
+    # Use false for argumentation datasets and datasets in which the labels are long sentences.
+    fill_gap_size: int = 1,  # If the projected label is split in two or more parts, we fill the gap if the gap size is less or equal than fill_gap_size.
+    # Else we will choose the largest label and remove the other part. Use True 1 if you are projection named entities or labels with a small number of words.
+    # Use a larger value for argumentation datasets and datasets in which the labels are long sentences.
 ) -> List[str]:
 
     assert len(source_tags_type) == len(source_tags_ids)
@@ -55,30 +62,32 @@ def sentence_projection(
             target_tags_types.append(source_tag_type)
 
     # REMOVE TAGS THAT ARE PUNCTUATION
+    if remove_puncs:
+        for target_tag_idx in range(len(target_tags_ids) - 1, -1, -1):
+            target_tags_c = target_tags_ids[target_tag_idx].copy()
+            for tag_idx in range(len(target_tags_ids[target_tag_idx]) - 1, -1, -1):
+                try:
+                    tword = target_words[
+                        target_tags_ids[target_tag_idx][tag_idx]
+                    ].strip()
+                except IndexError:
+                    raise IndexError(
+                        f"\ntarget_tags_ids: {target_tags_ids}\n"
+                        f"target_tags_c: {target_tags_c}\n"
+                        f"target_tags_ids[target_tag_idx]: {target_tags_ids[target_tag_idx]}\n"
+                        f"tag_idx: {tag_idx}\n"
+                        f"target_tag_idx:{target_tag_idx}\n"
+                        f"source_words: {source_words}\n"
+                        f"target_words: {target_words}\n"
+                    )
+                if all([char in puncs for char in tword]):
+                    # print(f"Warning: Removing word: {tword} from projected tag. ")
+                    del target_tags_ids[target_tag_idx][tag_idx]
 
-    for target_tag_idx in range(len(target_tags_ids) - 1, -1, -1):
-        target_tags_c = target_tags_ids[target_tag_idx].copy()
-        for tag_idx in range(len(target_tags_ids[target_tag_idx]) - 1, -1, -1):
-            try:
-                tword = target_words[target_tags_ids[target_tag_idx][tag_idx]].strip()
-            except IndexError:
-                raise IndexError(
-                    f"\ntarget_tags_ids: {target_tags_ids}\n"
-                    f"target_tags_c: {target_tags_c}\n"
-                    f"target_tags_ids[target_tag_idx]: {target_tags_ids[target_tag_idx]}\n"
-                    f"tag_idx: {tag_idx}\n"
-                    f"target_tag_idx:{target_tag_idx}\n"
-                    f"source_words: {source_words}\n"
-                    f"target_words: {target_words}\n"
-                )
-            if all([char in puncs for char in tword]):
-                # print(f"Warning: Removing word: {tword} from projected tag. ")
-                del target_tags_ids[target_tag_idx][tag_idx]
-
-        if len(target_tags_ids[target_tag_idx]) == 0:
-            del target_tags_ids[target_tag_idx]
-            del target_tags_types[target_tag_idx]
-            # print(f"Warning: Removing tag: {[target_words[i] for i in target_tags_c]}")
+            if len(target_tags_ids[target_tag_idx]) == 0:
+                del target_tags_ids[target_tag_idx]
+                del target_tags_types[target_tag_idx]
+                # print(f"Warning: Removing tag: {[target_words[i] for i in target_tags_c]}")
 
     # FIX DISCONTINUOUS SPANS
 
@@ -97,7 +106,7 @@ def sentence_projection(
 
         i = 0
         while i < len(groups) - 1:
-            if groups[i + 1][-1] - groups[i][0] <= 2:
+            if groups[i + 1][-1] - groups[i][0] <= (fill_gap_size + 1):
 
                 groups[i] = (
                     groups[i]
@@ -174,6 +183,8 @@ def sentences_projection(
     sources_tags_ids: List[List[List[int]]],
     target_words: List[List[str]],
     alignments: List[Dict],
+    remove_puncs: bool = True,
+    fill_gap_size: int = 1,
 ) -> str:
 
     assert (
@@ -212,6 +223,8 @@ def sentences_projection(
                 source_tags_ids=source_tags_ids,
                 target_words=target_words,
                 alignments=alignments,
+                remove_puncs=remove_puncs,
+                fill_gap_size=fill_gap_size,
             )
 
             assert len(target_words) == len(target_tags)
@@ -234,6 +247,8 @@ def dataset_projection(
     alignments_path: str,
     batch_size: int,
     output_path: str,
+    remove_puncs: bool = True,
+    fill_gap_size: int = 1,
 ):
     print(
         f"Datset projection:\n"
@@ -262,6 +277,10 @@ def dataset_projection(
 
     projections = []
 
+    projection_function = partial(
+        sentences_projection, remove_puncs=remove_puncs, fill_gap_size=fill_gap_size
+    )
+
     with open(output_path, "w+", encoding="utf8") as output_file, tqdm(
         total=data_loader_len, desc="Annotation projection"
     ) as pbar:
@@ -275,7 +294,7 @@ def dataset_projection(
             with multiprocessing.Pool(os.cpu_count()) as pool:
 
                 async_job = pool.starmap_async(
-                    sentences_projection,
+                    projection_function,
                     zip(
                         batch(source_words, n=os.cpu_count()),
                         batch(tags_type, n=os.cpu_count()),

--- a/projection/annotation_proyection.py
+++ b/projection/annotation_proyection.py
@@ -27,8 +27,9 @@ def sentence_projection(
     remove_puncs: bool = True,  # If a source word is aligned to a punctuation mark, we remove the alignment.
     # Use True if you are projection named entities or labels with a small number of words.
     # Use false for argumentation datasets and datasets in which the labels are long sentences.
-    fill_gap_size: int = 1,  # If the projected label is split in two or more parts, we fill the gap if the gap size is less or equal than fill_gap_size.
-    # Else we will choose the largest label and remove the other part. Use True 1 if you are projection named entities or labels with a small number of words.
+    fill_gap_size: int = 1,  # If the projected label is split in two or more parts, we fill the gap if the gap size is
+    # less or equal than fill_gap_size.  Else we will choose the largest label and remove the other part.
+    # Use True 1 if you are projection named entities or labels with a small number of words.
     # Use a larger value for argumentation datasets and datasets in which the labels are long sentences.
 ) -> List[str]:
 


### PR DESCRIPTION
Allow modifying the projection algorithm behavior with two new flags. These flags allow to successfully modify the hyper-parameters to use the code for projecting agumentation datasets. If not set, the behavior is the same than before. 